### PR TITLE
Fix for C++11 compilation

### DIFF
--- a/trove/utility.h
+++ b/trove/utility.h
@@ -79,7 +79,7 @@ __host__ __device__ T sum(const array<T, s>& a) {
 
 template<int m>
 struct static_log {
-    static const int value = 1 + static_log<m >> 1>::value;
+    static const int value = 1 + static_log< (m >> 1) >::value;
 };
 
 template<>


### PR DESCRIPTION
This trivial fix closes #3.  Not sure why this is a C++11 specific parsing issue, but c'est la vie, it fixes it.