### PR TITLE
Convert #define into anonymous enum

### DIFF
--- a/trove/warp.h
+++ b/trove/warp.h
@@ -38,8 +38,10 @@ inline bool warp_converged() {
 
 #undef WARP_CONVERGED
 
-#define WARP_SIZE 32
-#define WARP_MASK 0x1f
-#define LOG_WARP_SIZE 5
+enum {
+    WARP_SIZE = 32,
+    WARP_MASK = 0x1f,
+    LOG_WARP_SIZE = 5
+};
 
 }


### PR DESCRIPTION
This pull request converts several warp-related constants into a namespaced anonymous enum to avoid potential conflicts with other libraries. Specifically, currently it is not possible to compile code that includes `trove` and OpenCV's `cudev` module, because the latter has the [same constants](https://github.com/opencv/opencv/blob/b333b1f6e8564cfd10f0b14f71149b6fa637313b/modules/cudev/include/opencv2/cudev/warp/warp.hpp#L58).