### PR TITLE
fix __ballot and __shfl warnings for CUDA9+

### DIFF
--- a/trove/aos.h
+++ b/trove/aos.h
@@ -108,7 +108,11 @@ template<typename T>
 __device__ typename detail::dismember_type<T>::type*
 compute_address(T* src, int div, int mod) {
     typedef typename detail::dismember_type<T>::type U;
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 9000
+    T* base_ptr = __shfl_sync(0xFFFFFFFF, src, div);
+#else
     T* base_ptr = __shfl(src, div);
+#endif
     U* result = ((U*)(base_ptr) + mod);
     return result;
 }
@@ -189,7 +193,11 @@ template<typename T>
 __device__
 bool is_contiguous(int warp_id, const T* ptr) {
     int neighbor_idx = (warp_id == 0) ? 0 : warp_id-1;
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 9000
+    const T* neighbor_ptr = __shfl_sync(0xFFFFFFFF, ptr, neighbor_idx);
+#else
     const T* neighbor_ptr = __shfl(ptr, neighbor_idx);
+#endif
     bool neighbor_contiguous = (warp_id == 0) ? true : (ptr - neighbor_ptr == sizeof(T));
     bool result = __all(neighbor_contiguous);
     return result;

--- a/trove/aos.h
+++ b/trove/aos.h
@@ -109,7 +109,7 @@ __device__ typename detail::dismember_type<T>::type*
 compute_address(T* src, int div, int mod) {
     typedef typename detail::dismember_type<T>::type U;
 #if defined(CUDART_VERSION) && CUDART_VERSION >= 9000
-    T* base_ptr = __shfl_sync(0xFFFFFFFF, src, div);
+    T* base_ptr = __shfl_sync(WARP_CONVERGED, src, div);
 #else
     T* base_ptr = __shfl(src, div);
 #endif
@@ -194,7 +194,7 @@ __device__
 bool is_contiguous(int warp_id, const T* ptr) {
     int neighbor_idx = (warp_id == 0) ? 0 : warp_id-1;
 #if defined(CUDART_VERSION) && CUDART_VERSION >= 9000
-    const T* neighbor_ptr = __shfl_sync(0xFFFFFFFF, ptr, neighbor_idx);
+    const T* neighbor_ptr = __shfl_sync(WARP_CONVERGED, ptr, neighbor_idx);
 #else
     const T* neighbor_ptr = __shfl(ptr, neighbor_idx);
 #endif

--- a/trove/shfl.h
+++ b/trove/shfl.h
@@ -37,7 +37,7 @@ struct shuffle {
     __device__
     static void impl(array<int, s>& d, const int& i) {
 #if defined(CUDART_VERSION) && CUDART_VERSION >= 9000
-        d.head = __shfl_sync(0xFFFFFFFF, d.head, i);
+        d.head = __shfl_sync(WARP_CONVERGED, d.head, i);
 #else
         d.head = __shfl(d.head, i);
 #endif
@@ -50,7 +50,7 @@ struct shuffle<1> {
     __device__
     static void impl(array<int, 1>& d, const int& i) {
 #if defined(CUDART_VERSION) && CUDART_VERSION >= 9000
-        d.head = __shfl_sync(0xFFFFFFFF, d.head, i);
+        d.head = __shfl_sync(WARP_CONVERGED, d.head, i);
 #else
         d.head = __shfl(d.head, i);
 #endif

--- a/trove/transpose.h
+++ b/trove/transpose.h
@@ -417,7 +417,11 @@ template<typename T, int m>
 struct warp_shuffle<array<T, m>, array<int, m> > {
     __device__ static void impl(array<T, m>& d,
                                 const array<int, m>& i) {
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 9000
+        d.head = __shfl_sync(0xFFFFFFFF, d.head, i.head);
+#else
         d.head = __shfl(d.head, i.head);
+#endif
         warp_shuffle<array<T, m-1>, array<int, m-1> >::impl(d.tail,
                                                             i.tail);
     }
@@ -427,7 +431,11 @@ template<typename T>
 struct warp_shuffle<array<T, 1>, array<int, 1> > {
     __device__ static void impl(array<T, 1>& d,
                                 const array<int, 1>& i) {
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 9000
+        d.head = __shfl_sync(0xFFFFFFFF, d.head, i.head);
+#else
         d.head = __shfl(d.head, i.head);
+#endif
     }
 };
 

--- a/trove/transpose.h
+++ b/trove/transpose.h
@@ -418,7 +418,7 @@ struct warp_shuffle<array<T, m>, array<int, m> > {
     __device__ static void impl(array<T, m>& d,
                                 const array<int, m>& i) {
 #if defined(CUDART_VERSION) && CUDART_VERSION >= 9000
-        d.head = __shfl_sync(0xFFFFFFFF, d.head, i.head);
+        d.head = __shfl_sync(WARP_CONVERGED, d.head, i.head);
 #else
         d.head = __shfl(d.head, i.head);
 #endif
@@ -432,7 +432,7 @@ struct warp_shuffle<array<T, 1>, array<int, 1> > {
     __device__ static void impl(array<T, 1>& d,
                                 const array<int, 1>& i) {
 #if defined(CUDART_VERSION) && CUDART_VERSION >= 9000
-        d.head = __shfl_sync(0xFFFFFFFF, d.head, i.head);
+        d.head = __shfl_sync(WARP_CONVERGED, d.head, i.head);
 #else
         d.head = __shfl(d.head, i.head);
 #endif

--- a/trove/warp.h
+++ b/trove/warp.h
@@ -29,7 +29,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace trove {
 
-#define WARP_CONVERGED 0xffffffff
+enum {
+    WARP_SIZE = 32,
+    WARP_MASK = 0x1f,
+    WARP_CONVERGED = 0xFFFFFFFF,
+    LOG_WARP_SIZE = 5
+};
 
 __device__
 inline bool warp_converged() {
@@ -39,13 +44,5 @@ inline bool warp_converged() {
     return (__ballot(true) == WARP_CONVERGED);
 #endif
 }
-
-#undef WARP_CONVERGED
-
-enum {
-    WARP_SIZE = 32,
-    WARP_MASK = 0x1f,
-    LOG_WARP_SIZE = 5
-};
 
 }

--- a/trove/warp.h
+++ b/trove/warp.h
@@ -33,7 +33,11 @@ namespace trove {
 
 __device__
 inline bool warp_converged() {
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 9000
+    return (__activemask() == WARP_CONVERGED);
+#else
     return (__ballot(true) == WARP_CONVERGED);
+#endif
 }
 
 #undef WARP_CONVERGED


### PR DESCRIPTION
added __shfl_sync() / __activemask() calls to prevent deprecation warnings when using CUDA 9. Tested on the benchmark and block programs with CUDA 8.0 and CUDA 9.0.

Warning: this is my first time opening a pull request, and I'm not an expert!

addresses issue #8