### PR TITLE
Handle warp configurations for 2D and 3D blocks

### DIFF
--- a/trove/warp.h
+++ b/trove/warp.h
@@ -36,6 +36,10 @@ enum {
     LOG_WARP_SIZE = 5
 };
 
+inline __device__ int thread_id() {
+  return (threadIdx.z*blockDim.y + threadIdx.y)*blockDim.x + threadIdx.x;
+}
+
 __device__
 inline bool warp_converged() {
 #if defined(CUDART_VERSION) && CUDART_VERSION >= 9000


### PR DESCRIPTION
I noticed that the warp_id calculation within much of the code assumes a 1D thread block. Is this an assumed limitation when using trove?

```c++
int warp_id = threadIdx.x & WARP_MASK;
```

To [cater for 2D and 3D blocks](https://devtalk.nvidia.com/default/topic/498823/cuda-programming-and-performance/warp-layout-in-a-2d-thread-block-/post/3565057/#3565057) this should probably be

```c++
int warp_id = (threadIdx.z*blockDim.y + threadIdx.y)*blockDimx.x + threadIdx.x;
```

This PR makes the above change, but I'm not sure if its worth going further if the actual algorithm internals depend on a 1D thread block?
