### PR TITLE
explicitly define underlying enum type

### DIFF
--- a/trove/warp.h
+++ b/trove/warp.h
@@ -29,7 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace trove {
 
-enum {
+enum : unsigned {
     WARP_SIZE = 32,
     WARP_MASK = 0x1f,
     WARP_CONVERGED = 0xFFFFFFFF,


### PR DESCRIPTION
on CUDA11 w/ MSVC 2019, I get a lot of warnings when using trove:
```
[build] F:\fem_performance_tests\extern\trove\trove/warp.h(42): warning: integer conversion resulted in a change of sign
[build] 
[build] F:\fem_performance_tests\extern\trove\trove/shfl.h(53): warning: integer conversion resulted in a change of sign
[build] 
[build] F:\fem_performance_tests\extern\trove\trove/transpose.h(421): warning: integer conversion resulted in a change of sign
.
.
.
```
They seem to be addressed by manually specifying the underlying type for the enum in warp.h.