### PR TITLE
Feature/coop refine

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,3 +12,6 @@ benchmark: benchmark.cu
 
 block: block.cu
 	$(NVCC) -arch=$(ARCH) -I../ -Xptxas -v block.cu -o block
+
+clean:
+	rm -f *.o benchmark block

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,7 @@
 ARCH ?= sm_70
 LOWER_BOUND ?= 1
 UPPER_BOUND ?= 16
+TILE_SIZE ?= 32
 
 CUDA_HOME ?= /usr/local/cuda
 NVCC = $(CUDA_HOME)/bin/nvcc
@@ -8,10 +9,10 @@ NVCC = $(CUDA_HOME)/bin/nvcc
 all: benchmark block
 
 benchmark: benchmark.cu
-	$(NVCC) -arch=$(ARCH) -I../ -Xptxas -v benchmark.cu -o benchmark -DLOWER_BOUND=$(LOWER_BOUND) -DUPPER_BOUND=$(UPPER_BOUND)
+	$(NVCC) -arch=$(ARCH) -I../ -Xptxas -v benchmark.cu -o benchmark -DLOWER_BOUND=$(LOWER_BOUND) -DUPPER_BOUND=$(UPPER_BOUND) -DTILE_SIZE=$(TILE_SIZE)
 
 block: block.cu
-	$(NVCC) -arch=$(ARCH) -I../ -Xptxas -v block.cu -o block
+	$(NVCC) -arch=$(ARCH) -I../ -Xptxas -v block.cu -o block -DTILE_SIZE=$(TILE_SIZE)
 
 clean:
 	rm -f *.o benchmark block

--- a/tests/benchmark.cu
+++ b/tests/benchmark.cu
@@ -130,7 +130,7 @@ void run_benchmark_contiguous_store(const std::string name, void (*test)(array<i
     std::cout << name << ", " << i << ", ";
     int n_blocks = 80 * 8 * 100;
     int block_size = 256;
-    int n = n_blocks * block_size - 100;
+    int n = n_blocks * block_size;
     thrust::device_vector<T> r(n);
     int iterations = 10;
     cuda_timer timer;

--- a/tests/benchmark.cu
+++ b/tests/benchmark.cu
@@ -344,7 +344,7 @@ template<template<int> class F>
 struct do_tests<F, null_type> {
     static void impl() {}
     template<typename T>
-    static void impl(const T& t) {}
+    static void impl(const T&) {}
 };
 
 #ifndef LOWER_BOUND

--- a/tests/benchmark.cu
+++ b/tests/benchmark.cu
@@ -44,6 +44,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace trove;
 
+// tile size to use for low-level load/store warp contiguous
+#ifndef TILE_SIZE
+#define TILE_SIZE 32
+#endif
+
 template<typename T>
 __global__ void
 benchmark_contiguous_shfl_store(T* r) {
@@ -52,7 +57,7 @@ benchmark_contiguous_shfl_store(T* r) {
     int size = detail::aliased_size<T, int>::value;
     data = counting_array<T>::impl(
         global_index * size);
-    store_warp_contiguous(data, r + global_index);    
+    store_warp_contiguous<TILE_SIZE>(data, r + global_index);
 }
 
 template<typename T>
@@ -70,7 +75,7 @@ template<typename T>
 __global__ void
 benchmark_contiguous_shfl_load(T* s, typename T::value_type* r) {
     int global_index = threadIdx.x + blockDim.x * blockIdx.x;
-    T data = load_warp_contiguous(s + global_index);
+    T data = load_warp_contiguous<TILE_SIZE>(s + global_index);
     r[global_index] = sum(data);
 }
 

--- a/trove/aos.h
+++ b/trove/aos.h
@@ -265,6 +265,8 @@ __device__ T load(const T* src) {
         return detail::load_dispatch(src, thread_tile<WARP_SIZE/4>());
     } else if (warp_converged<WARP_SIZE/8>()) {
         return detail::load_dispatch(src, thread_tile<WARP_SIZE/8>());
+    } else if (warp_converged<WARP_SIZE/16>()) {
+        return detail::load_dispatch(src, thread_tile<WARP_SIZE/16>());
     } else {
         return detail::divergent_load(src);
     }
@@ -280,6 +282,8 @@ __device__ void store(const T& data, T* dest) {
         detail::store_dispatch(data, dest, thread_tile<WARP_SIZE/4>());
     } else if (warp_converged<WARP_SIZE/8>()) {
         detail::store_dispatch(data, dest, thread_tile<WARP_SIZE/8>());
+    } else if (warp_converged<WARP_SIZE/16>()) {
+        detail::store_dispatch(data, dest, thread_tile<WARP_SIZE/16>());
     } else {
         detail::divergent_store(data, dest);
     }

--- a/trove/aos.h
+++ b/trove/aos.h
@@ -256,11 +256,11 @@ template<typename T>
 __device__ T load(const T* src) {
     if (warp_converged()) {
         return detail::load_dispatch(src, thread_tile<WARP_SIZE>());
-    } else if (half_warp_converged()) {
+    } else if (warp_converged<WARP_SIZE/2>()) {
         return detail::load_dispatch(src, thread_tile<WARP_SIZE/2>());
-    } else if (quarter_warp_converged()) {
+    } else if (warp_converged<WARP_SIZE/4>()) {
         return detail::load_dispatch(src, thread_tile<WARP_SIZE/4>());
-    } else if (eighth_warp_converged()) {
+    } else if (warp_converged<WARP_SIZE/8>()) {
         return detail::load_dispatch(src, thread_tile<WARP_SIZE/8>());
     } else {
         return detail::divergent_load(src);
@@ -271,11 +271,11 @@ template<typename T>
 __device__ void store(const T& data, T* dest) {
     if (warp_converged()) {
         detail::store_dispatch(data, dest, thread_tile<WARP_SIZE>());
-    } else if (half_warp_converged()) {
+    } else if (warp_converged<WARP_SIZE/2>()) {
         detail::store_dispatch(data, dest, thread_tile<WARP_SIZE/2>());
-    } else if (quarter_warp_converged()) {
+    } else if (warp_converged<WARP_SIZE/4>()) {
         detail::store_dispatch(data, dest, thread_tile<WARP_SIZE/4>());
-    } else if (eighth_warp_converged()) {
+    } else if (warp_converged<WARP_SIZE/8>()) {
         detail::store_dispatch(data, dest, thread_tile<WARP_SIZE/8>());
     } else {
         detail::divergent_store(data, dest);

--- a/trove/aos.h
+++ b/trove/aos.h
@@ -62,9 +62,10 @@ struct use_direct {
 }
 
 
-template<typename T, typename Tile = thread_tile<WARP_SIZE>>
+template<size_t tile_size = WARP_SIZE, typename T>
 __device__ typename enable_if<detail::use_shfl<T>::value, T>::type
-load_warp_contiguous(const T* src, const Tile &tile = Tile()) {
+load_warp_contiguous(const T* src) {
+    thread_tile<tile_size> tile;
     int warp_id = tile.id();
     const T* warp_begin_src = src - warp_id;
     typedef typename detail::dismember_type<T>::type U;
@@ -75,16 +76,17 @@ load_warp_contiguous(const T* src, const Tile &tile = Tile()) {
     return detail::fuse<T>(loaded);
 }
 
-template<typename T, typename Tile = thread_tile<WARP_SIZE>>
+template<size_t tile_size = WARP_SIZE, typename T>
 __device__ typename enable_if<detail::use_direct<T>::value, T>::type
-load_warp_contiguous(const T* src, const Tile & = Tile()) {
+load_warp_contiguous(const T* src) {
     return detail::divergent_load(src);
 }
 
 
-template<typename T, typename Tile = thread_tile<WARP_SIZE>>
+template<size_t tile_size = WARP_SIZE, typename T>
 __device__ typename enable_if<detail::use_shfl<T>::value>::type
-store_warp_contiguous(const T& data, T* dest, const Tile &tile = Tile()) {
+store_warp_contiguous(const T& data, T* dest) {
+    thread_tile<tile_size> tile;
     int warp_id = tile.id();
     T* warp_begin_dest = dest - warp_id;
     typedef typename detail::dismember_type<T>::type U;
@@ -95,9 +97,9 @@ store_warp_contiguous(const T& data, T* dest, const Tile &tile = Tile()) {
     warp_store(lysed, as_int_dest, warp_id, tile.size());
 }
 
-template<typename T, typename Tile = thread_tile<WARP_SIZE>>
+template<size_t tile_size = WARP_SIZE, typename T>
 __device__ typename enable_if<detail::use_direct<T>::value>::type
-store_warp_contiguous(const T& data, T* dest, const Tile & = Tile()) {
+store_warp_contiguous(const T& data, T* dest) {
     detail::divergent_store(data, dest);
 }
 

--- a/trove/array.h
+++ b/trove/array.h
@@ -127,88 +127,21 @@ T get(const array<T, m>& src) {
 
 template<typename T>
 __host__ __device__
-array<T, 0> make_array() {
+auto make_array() {
     return array<T, 0>();
 }
 
 template<typename T>
 __host__ __device__
-array<T, 1> make_array(T a0) {
+auto make_array(T a0) {
     return array<T, 1>(a0);
 }
 
-template<typename T>
+template <typename T, typename... Args>
 __host__ __device__
-array<T, 2> make_array(T a0, T a1) {
-    return array<T, 2>(a0,
-                       make_array<T>(a1));
+auto make_array(T a0, Args... args) {
+    return array<T, 1 + sizeof...(Args)>(a0, make_array<T>(args...));
 }
-
-template<typename T>
-__host__ __device__
-array<T, 3> make_array(T a0, T a1, T a2) {
-    return array<T, 3>(a0,
-                       make_array<T>(a1, a2));
-}
-
-template<typename T>
-__host__ __device__
-array<T, 4> make_array(T a0, T a1, T a2, T a3) {
-    return array<T, 4>(a0,
-                       make_array<T>(a1, a2, a3));
-}
-
-template<typename T>
-__host__ __device__
-array<T, 5> make_array(T a0, T a1, T a2, T a3, T a4) {
-    return array<T, 5>(a0,
-                       make_array<T>(a1, a2, a3, a4));
-}
-
-template<typename T>
-__host__ __device__
-array<T, 6> make_array(T a0, T a1, T a2, T a3, T a4,
-                       T a5) {
-    return array<T, 6>(a0,
-                       make_array<T>(a1, a2, a3, a4, a5));
-}
-
-template<typename T>
-__host__ __device__
-array<T, 7> make_array(T a0, T a1, T a2, T a3, T a4,
-                       T a5, T a6) {
-    return array<T, 7>(a0,
-                       make_array<T>(a1, a2, a3, a4, a5,
-                                     a6));
-}
-
-template<typename T>
-__host__ __device__
-array<T, 8> make_array(T a0, T a1, T a2, T a3, T a4,
-                       T a5, T a6, T a7) {
-    return array<T, 8>(a0,
-                       make_array<T>(a1, a2, a3, a4, a5,
-                                     a6, a7));
-}
-
-template<typename T>
-__host__ __device__
-array<T, 9> make_array(T a0, T a1, T a2, T a3, T a4,
-                       T a5, T a6, T a7, T a8) {
-    return array<T, 9>(a0,
-                       make_array<T>(a1, a2, a3, a4, a5,
-                                     a6, a7, a8));
-}
-
-template<typename T>
-__host__ __device__
-array<T, 10> make_array(T a0, T a1, T a2, T a3, T a4,
-                        T a5, T a6, T a7, T a8, T a9) {
-    return array<T, 10>(a0,
-                        make_array<T>(a1, a2, a3, a4, a5,
-                                      a6, a7, a8, a9));
-}
-
 
 namespace detail {
 

--- a/trove/block.h
+++ b/trove/block.h
@@ -32,12 +32,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace trove {
 
 
-template<int s, typename T, typename I>
+template<int s, size_t tile_size = WARP_SIZE, typename T, typename I>
 __device__
 trove::array<T, s> load_array_warp_contiguous(const T* src, const I& idx) {
     typedef trove::array<T, s> array_type;
     const array_type* src_ptr = (const array_type*)(src) + idx;
-    return load_warp_contiguous(src_ptr);
+    return load_warp_contiguous<tile_size>(src_ptr);
 }
 
 template<int s, typename T, typename I>
@@ -48,12 +48,12 @@ trove::array<T, s> load_array(const T* src, const I& idx) {
     return *src_ptr;
 }
 
-template<int s, typename T, typename I>
+template<int s, size_t tile_size = WARP_SIZE, typename T, typename I>
 __device__
 void store_array_warp_contiguous(T* dest, const I& idx, const trove::array<T, s>& src) {
     typedef trove::array<T, s> array_type;
     array_type* dest_ptr = (array_type*)(dest) + idx;
-    store_warp_contiguous(src, dest_ptr);
+    store_warp_contiguous<tile_size>(src, dest_ptr);
 }
 
 template<int s, typename T, typename I>

--- a/trove/ptr.h
+++ b/trove/ptr.h
@@ -60,6 +60,10 @@ struct coalesced_ref {
             auto tile = thread_tile<WARP_SIZE/8>();
             T data = detail::load_dispatch(other.m_ptr, tile);
             detail::store_dispatch(data, m_ptr, tile);
+        } else if (warp_converged<WARP_SIZE/16>()) {
+            auto tile = thread_tile<WARP_SIZE/16>();
+            T data = detail::load_dispatch(other.m_ptr, tile);
+            detail::store_dispatch(data, m_ptr, tile);
         } else {
             T data = detail::divergent_load(other.m_ptr);
             detail::divergent_store(data, m_ptr);

--- a/trove/ptr.h
+++ b/trove/ptr.h
@@ -48,15 +48,15 @@ struct coalesced_ref {
         if (warp_converged()) {
             T data = detail::load_dispatch(other.m_ptr);
             detail::store_dispatch(data, m_ptr);
-        } else if (half_warp_converged()) {
+        } else if (warp_converged<WARP_SIZE/2>()) {
             auto tile = thread_tile<WARP_SIZE/2>();
             T data = detail::load_dispatch(other.m_ptr, tile);
             detail::store_dispatch(data, m_ptr, tile);
-        } else if (quarter_warp_converged()) {
+        } else if (warp_converged<WARP_SIZE/4>()) {
             auto tile = thread_tile<WARP_SIZE/4>();
             T data = detail::load_dispatch(other.m_ptr, tile);
             detail::store_dispatch(data, m_ptr, tile);
-        } else if (eighth_warp_converged()) {
+        } else if (warp_converged<WARP_SIZE/8>()) {
             auto tile = thread_tile<WARP_SIZE/8>();
             T data = detail::load_dispatch(other.m_ptr, tile);
             detail::store_dispatch(data, m_ptr, tile);

--- a/trove/transpose.h
+++ b/trove/transpose.h
@@ -513,12 +513,12 @@ struct c2r_warp_transpose_impl<Array, Indices, composite> {
                                 const Indices& indices,
                                 const int& rotation,
                                 const Tile &tile) {
-        int warp_id = tile.id;
+        int warp_id = tile.id();
         int pre_rotation = warp_id >> static_log<tile.size()/static_gcd<Array::size, tile.size()>::value>::value;
         src = rotate(src, pre_rotation);
         detail::warp_shuffle<Array, Indices>::impl(src, indices, tile);
         src = rotate(src, rotation);
-        src = composite_c2r_tx_permute(src);
+        src = composite_c2r_tx_permute<Tile>(src);
     }
 };
 
@@ -617,7 +617,7 @@ struct r2c_warp_transpose_impl<Array, Indices, composite> {
                                 const Tile &tile) {
         constexpr int c = static_gcd<Array::size, Tile::size()>::value;
         int warp_id = tile.id();
-        src = composite_r2c_tx_permute(src);
+        src = composite_r2c_tx_permute<Tile>(src);
         src = rotate(src, rotation);
         detail::warp_shuffle<Array, Indices>::impl(src, indices, tile);
         src = rotate(src, size - (warp_id/(Tile::size()/c)));

--- a/trove/warp.h
+++ b/trove/warp.h
@@ -53,9 +53,11 @@ struct thread_tile {
   __device__ auto id() const { return tile.thread_rank(); }
 };
 
+template <size_t warp_size = WARP_SIZE>
 __device__ inline bool warp_converged() { return (__activemask() == WARP_CONVERGED); }
 
-__device__ inline bool half_warp_converged()
+template <>
+__device__ inline bool warp_converged<16>()
 {
   auto lane_id = ((threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x + threadIdx.x) & 31;
   auto shift = lane_id & ~0xe;
@@ -63,7 +65,8 @@ __device__ inline bool half_warp_converged()
   return (__activemask() & lane_mask) == lane_mask;
 }
 
-__device__ inline bool quarter_warp_converged()
+template <>
+__device__ inline bool warp_converged<8>()
 {
   auto lane_id = ((threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x + threadIdx.x) & 31;
   auto shift = lane_id & ~0x7;
@@ -71,7 +74,8 @@ __device__ inline bool quarter_warp_converged()
   return (__activemask() & lane_mask) == lane_mask;
 }
 
-__device__ inline bool eighth_warp_converged()
+template <>
+__device__ inline bool warp_converged<4>()
 {
   auto lane_id = ((threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x + threadIdx.x) & 31;
   auto shift = lane_id & ~0x3;

--- a/trove/warp.h
+++ b/trove/warp.h
@@ -60,7 +60,7 @@ template <>
 __device__ inline bool warp_converged<16>()
 {
   auto lane_id = ((threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x + threadIdx.x) & 31;
-  auto shift = lane_id & ~0xe;
+  auto shift = lane_id & ~0xf;
   auto lane_mask = 65535 << shift;
   return (__activemask() & lane_mask) == lane_mask;
 }

--- a/trove/warp.h
+++ b/trove/warp.h
@@ -83,4 +83,13 @@ __device__ inline bool warp_converged<4>()
   return (__activemask() & lane_mask) == lane_mask;
 }
 
+template <>
+__device__ inline bool warp_converged<2>()
+{
+  auto lane_id = ((threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x + threadIdx.x) & 31;
+  auto shift = lane_id & ~0x1;
+  auto lane_mask = 4 << shift;
+  return (__activemask() & lane_mask) == lane_mask;
+}
+
 }


### PR DESCRIPTION
This PR cleans up the prior #16, and fixes some issues:
* fix long standing invalid memory access in `run_benchmark_contiguous_store` (incorrect problem size)
* cleanup of `warp_converged` functions to use a template size parameter
* warp-contiguous interface now use a non-type tile size rather than explicit `thread_tile` template
* fix bug with `warp_converged<16>` function (wrong bit-mask used)
* add support for thread tiles of size 2
* `size_in_range` needs to take into account `tile_size` when deciding if `shfl` path can be taken